### PR TITLE
set pointerEvents to none to pass through pointer events

### DIFF
--- a/MMM-AutoDimmer.js
+++ b/MMM-AutoDimmer.js
@@ -373,6 +373,7 @@ Module.register("MMM-AutoDimmer", {
 			self.overlay.style.bottom = "0px";
 			self.overlay.style["z-index"] = 9999;
 			self.overlay.style.opacity = 0.0;
+			self.overlay.style.pointerEvents = "none";
 		}
 
 		self.opacity = 0;


### PR DESCRIPTION
The auto dimmer won't let any clickable elements be clickable because the overlay is blocking them.

Quick one line fix to set the `pointer-events` property of the overlay to `"none"`, thereby passing the pointer events through and making the modules clickable again.